### PR TITLE
fix query allDomains

### DIFF
--- a/src/handler.ts
+++ b/src/handler.ts
@@ -130,10 +130,10 @@ async function queryGraph(endpoint: string, query: string): Promise<any> {
 async function fetchEns(address: string): Promise<Array<string>> {
   const endpoint = "https://api.thegraph.com/subgraphs/name/ensdomains/ens";
   const query = `{
-    domains(where:{owner:"${address.toLowerCase()}"}) {
+    domains(first: 1065, where: {owner: "${address.toLowerCase()}"}) {
       name
     }
-    wrappedDomains(where: { owner: "${address.toLowerCase()}"}) {
+    wrappedDomains(first: 1065, where: {owner: "${address.toLowerCase()}"}) {
       name
     }
   }`;


### PR DESCRIPTION
Extreme test case: https://ens-reverse-lookup.next.id/ens/0xa74fc66e75f883ee8e60e287335436ca8e6a303c

ENS reverse lookup has more strict logic, it requires that the domain name reverse record must indeed owned by same wallet
```
// if reverse record is set, validate addr owns this domain.
if (reverseRecord != null && !allDomains.includes(reverseRecord)) {
console.warn("Failed to validate! Reverse record set to " + reverseRecord + ", but user does not own this name.");
reverseRecord = null;
}
```

`function fetchEns(address: string)` returns incomplete results when querying data from `TheGraph`.
Because `TheGraph` returns default item size is 100, but if `primary_name` not in these 100 items, `allDomains` array does not contain `primary_name`, which will lead to entering this judgment condition reverseRecord = null.

The return item size must be explicitly declared `first: 1065`.